### PR TITLE
Remove unused results_log configuration option

### DIFF
--- a/cypher/driver/benchmark.properties
+++ b/cypher/driver/benchmark.properties
@@ -11,7 +11,6 @@ status=1
 thread_count=1
 name=LDBC-SNB
 mode=execute_benchmark
-results_log=true
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/cypher/driver/create-validation-parameters.properties
+++ b/cypher/driver/create-validation-parameters.properties
@@ -11,7 +11,6 @@ status=1
 thread_count=1
 name=LDBC-SNB
 mode=create_validation
-results_log=false
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/cypher/driver/validate.properties
+++ b/cypher/driver/validate.properties
@@ -11,7 +11,6 @@ status=1
 thread_count=1
 mode=validate_database
 name=LDBC-SNB
-results_log=false
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/duckdb/driver/benchmark.properties
+++ b/duckdb/driver/benchmark.properties
@@ -8,7 +8,6 @@ status=1
 thread_count=1
 name=LDBC-SNB
 mode=execute_benchmark
-results_log=true
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/duckdb/driver/create-validation-parameters.properties
+++ b/duckdb/driver/create-validation-parameters.properties
@@ -8,7 +8,6 @@ status=1
 thread_count=1
 mode=create_validation
 name=LDBC-SNB
-results_log=false
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/duckdb/driver/validate.properties
+++ b/duckdb/driver/validate.properties
@@ -8,7 +8,6 @@ status=1
 thread_count=1
 mode=validate_database
 name=LDBC-SNB
-results_log=false
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/graphdb/driver/benchmark.properties
+++ b/graphdb/driver/benchmark.properties
@@ -9,7 +9,6 @@ status=1
 thread_count=1
 name=LDBC-SNB
 mode=execute_benchmark
-results_log=true
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/graphdb/driver/create-validation-parameters.properties
+++ b/graphdb/driver/create-validation-parameters.properties
@@ -9,7 +9,6 @@ status=1
 thread_count=1
 name=LDBC-SNB
 mode=create_validation
-results_log=false
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/graphdb/driver/validate.properties
+++ b/graphdb/driver/validate.properties
@@ -9,7 +9,6 @@ status=1
 thread_count=1
 name=LDBC-SNB
 mode=validate_database
-results_log=false
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/postgres/driver/benchmark.properties
+++ b/postgres/driver/benchmark.properties
@@ -13,7 +13,6 @@ status=1
 thread_count=1
 name=LDBC-SNB
 mode=execute_benchmark
-results_log=true
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/postgres/driver/create-validation-parameters.properties
+++ b/postgres/driver/create-validation-parameters.properties
@@ -13,7 +13,6 @@ status=1
 thread_count=1
 mode=create_validation
 name=LDBC-SNB
-results_log=false
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/postgres/driver/validate.properties
+++ b/postgres/driver/validate.properties
@@ -13,7 +13,6 @@ status=1
 thread_count=1
 mode=validate_database
 name=LDBC-SNB
-results_log=false
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/tigergraph/driver/benchmark.properties
+++ b/tigergraph/driver/benchmark.properties
@@ -10,7 +10,6 @@ status=1
 thread_count=1
 name=LDBC-SNB
 mode=execute_benchmark
-results_log=true
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/tigergraph/driver/create-validation-parameters-sf10.properties
+++ b/tigergraph/driver/create-validation-parameters-sf10.properties
@@ -9,7 +9,6 @@ printQueryResults=false
 status=1
 thread_count=1
 name=LDBC_SNB
-results_log=false
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/tigergraph/driver/create-validation-parameters.properties
+++ b/tigergraph/driver/create-validation-parameters.properties
@@ -10,7 +10,6 @@ status=1
 thread_count=1
 mode=create_validation
 name=LDBC_SNB
-results_log=false
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/tigergraph/driver/validate.properties
+++ b/tigergraph/driver/validate.properties
@@ -10,7 +10,6 @@ status=1
 thread_count=1
 mode=validate_database
 name=LDBC_SNB
-results_log=false
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/umbra/driver/benchmark.properties
+++ b/umbra/driver/benchmark.properties
@@ -13,7 +13,6 @@ status=1
 thread_count=4
 name=LDBC-SNB
 mode=execute_benchmark
-results_log=true
 time_unit=MILLISECONDS
 time_compression_ratio=0.1437
 peer_identifiers=

--- a/umbra/driver/create-validation-parameters.properties
+++ b/umbra/driver/create-validation-parameters.properties
@@ -13,7 +13,6 @@ status=1
 thread_count=1
 name=LDBC-SNB
 mode=create_validation
-results_log=false
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=

--- a/umbra/driver/validate.properties
+++ b/umbra/driver/validate.properties
@@ -13,7 +13,6 @@ status=1
 thread_count=1
 mode=validate_database
 name=LDBC-SNB
-results_log=false
 time_unit=MILLISECONDS
 time_compression_ratio=0.001
 peer_identifiers=


### PR DESCRIPTION
This PR removes the unused `results_log` configuration option. This option is not only not used, it's also confusing: the driver modes "create validation parameters" and "validate" do not produce a log file regardless of configuration, while the mode "benchmark" produces a configuration to the directory specified by the `results_dir` option (default: `results/`).

See the driver configuration class for details – there is no option called `results_log` in the first place: https://github.com/ldbc/ldbc_snb_interactive_v1_driver/blob/eed18de824e4c7a6304b431ea32c7deebd008dc5/src/main/java/org/ldbcouncil/snb/driver/control/ConsoleAndFileDriverConfiguration.java#L105-L110