### PR TITLE
Fix the TigerGraph Interactive Complex 3 implementation

### DIFF
--- a/tigergraph/queries/interactiveComplex3.gsql
+++ b/tigergraph/queries/interactiveComplex3.gsql
@@ -1,6 +1,6 @@
 CREATE OR REPLACE QUERY interactiveComplex3(VERTEX<Person> personId, STRING countryXName, STRING countryYName, INT startDate, INT durationDays) SYNTAX v2 {
   TYPEDEF TUPLE<INT personId, STRING personFirstName, STRING personLastName, INT xCount, INT yCount, INT xyCount> msgStats; 
-  HeapAccum<msgStats>(20, xCount DESC, personId ASC) @@result;
+  HeapAccum<msgStats>(20, xyCount DESC, personId ASC) @@result;
   SumAccum<UINT> @xCount, @yCount;
   MaxAccum<UINT> @@countryId1, @@countryId2;
   OrAccum<BOOL> @selected, @selected2;


### PR DESCRIPTION
<img width="1462" height="554" alt="image" src="https://github.com/user-attachments/assets/96e5e79a-5fe3-4862-ad2b-3dd396e30024" />
According to the specification document, Complex-3 must be sorted by `xyCount`.
